### PR TITLE
fix bug in rotation matching

### DIFF
--- a/imc2023/pipelines/pipeline.py
+++ b/imc2023/pipelines/pipeline.py
@@ -209,16 +209,16 @@ class Pipeline:
                     # rotate keypoints by -90 degrees
                     # ==> (x,y) becomes (y, x_max - x)
                     new_keypoints[:, 0] = keypoints[:, 1]
-                    new_keypoints[:, 1] = x_max - keypoints[:, 0]
+                    new_keypoints[:, 1] = x_max - keypoints[:, 0]-1
                 elif angle == 180:
                     # rotate keypoints by 180 degrees
                     # ==> (x,y) becomes (x_max - x, y_max - y)
-                    new_keypoints[:, 0] = x_max - keypoints[:, 0]
-                    new_keypoints[:, 1] = y_max - keypoints[:, 1]
+                    new_keypoints[:, 0] = x_max - keypoints[:, 0]-1
+                    new_keypoints[:, 1] = y_max - keypoints[:, 1]-1
                 elif angle == 270:
                     # rotate keypoints by +90 degrees
                     # ==> (x,y) becomes (y_max - y, x)
-                    new_keypoints[:, 0] = y_max - keypoints[:, 1]
+                    new_keypoints[:, 0] = y_max - keypoints[:, 1]-1
                     new_keypoints[:, 1] = keypoints[:, 0]
                 f[image_fn]["keypoints"][...] = new_keypoints
 


### PR DESCRIPTION
it improves mAA=0.577701 to mAA=0.613104 using SP+LG-rot on cyprus
index was off by one:
```
new_keypoints[:, 0] = x_max - keypoints[:, 0]
->
new_keypoints[:, 0] = x_max - keypoints[:, 0]-1
```