### PR TITLE
fix paths

### DIFF
--- a/imc2023/pipelines/pipeline.py
+++ b/imc2023/pipelines/pipeline.py
@@ -66,6 +66,7 @@ class Pipeline:
         self.args = args
 
         self.sparse_model = None
+        self.rotated_sparse_model = None
 
         self.is_ensemble = type(self.config["features"]) == list
         if self.is_ensemble:
@@ -192,19 +193,18 @@ class Pipeline:
         if not self.use_rotation_wrapper:
             return
         self.log_step("Back-rotate camera poses")
-
         for id, im in self.sparse_model.images.items():
             angle = self.rotation_angles[im.name]
             if angle !=0:
                 # back rotate <Image 'image_id=30, camera_id=30, name="DSC_6633.JPG", triangulated=404/3133'> by 90
-                logging.info(f"back rotate {im} by {angle}")
+                # logging.info(f"back rotate {im} by {angle}")
                 rotmat = rot_mat_z(angle)
-                logging.info(rotmat)
+                # logging.info(rotmat)
                 R = im.rotmat()
                 t = np.array(im.tvec)
                 self.sparse_model.images[id].tvec = rotmat @t
                 self.sparse_model.images[id].qvec = rotmat2qvec(rotmat @ R)
-        self.sparse_model.write(self.paths.sfm_dir)
+        # self.sparse_model.write(self.paths.sfm_dir)
         # swap the two image folders
         image_dir = self.paths.rotated_image_dir
         self.paths.rotated_image_dir = self.paths.image_dir

--- a/interactive.sh
+++ b/interactive.sh
@@ -1,0 +1,1 @@
+srun --gpus=1 -n 16 --mem-per-cpu=4096 --pty bash

--- a/main.py
+++ b/main.py
@@ -130,8 +130,7 @@ def main(args):
             logging.info("=" * 80)
             logging.info(f"{dataset} - {scene}")
             logging.info("=" * 80)
-            if scene != "cyprus":
-                continue
+            
             start_scene = time.time()
 
             # SETUP PATHS

--- a/main.py
+++ b/main.py
@@ -60,6 +60,8 @@ def get_output_dir(args: argparse.Namespace) -> Path:
         output_dir += "-pixsfm"
     if args.resize is not None:
         output_dir += f"-{args.resize}px"
+    if args.rotation_wrapper:
+        output_dir += "-rotwrap"
 
     output_dir = Path(output_dir)
     output_dir.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
This fixed the problem on kaggle for train. Probably as well for test. 

```
File /kaggle/input/imc-23-repo/IMC-2023/imc2023/preprocessing.py:23, in resize_image(image, max_size)
     13 def resize_image(image: np.ndarray, max_size: int) -> np.ndarray:
     14     """Resize image to max_size.
     15 
     16     Args:
   (...)
     21         np.ndarray: Resized image.
     22     """
---> 23     img_size = image.shape[:2]
     24     if max(img_size) > max_size:
     25         ratio = max_size / max(img_size)

AttributeError: 'NoneType' object has no attribute 'shape'
```